### PR TITLE
security: use server-generated request IDs in audit logs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -149,7 +149,11 @@ export function createApp(config: AppConfig) {
   );
 
   app.use((req: RequestWithContext, res, next) => {
-    req.requestId = req.header("x-request-id") ?? randomUUID();
+    req.requestId = randomUUID();
+    const callerRequestId = req.header("x-request-id");
+    if (callerRequestId) {
+      res.setHeader("x-caller-request-id", callerRequestId);
+    }
     res.setHeader("x-request-id", req.requestId);
     next();
   });


### PR DESCRIPTION
## Summary
- The request-id middleware previously trusted the caller's `x-request-id` header as the canonical ID in all audit log entries. A caller could inject arbitrary IDs to poison forensic logs or create false correlations.
- `requestId` is now always a server-generated UUID. The caller's original header is echoed back as `x-caller-request-id` for their own correlation but never enters the audit trail.

## Test plan
- [ ] Verify requests without `x-request-id` header get a server-generated UUID in logs and response
- [ ] Verify requests with `x-request-id: attacker-value` get a server-generated UUID in logs, and `x-caller-request-id: attacker-value` in the response
- [ ] Verify audit log `request_id` fields never contain caller-supplied values

🤖 Generated with [Claude Code](https://claude.com/claude-code)